### PR TITLE
OT195-40-v2

### DIFF
--- a/migrations/20220527155734-create-entry.js
+++ b/migrations/20220527155734-create-entry.js
@@ -27,7 +27,7 @@ module.exports = {
         onDelete: "SET NULL",
       },
       type: {
-        type: Sequelize.INTEGER,
+        type: Sequelize.STRING,
       },
       deletedAt: {
         type: Sequelize.DATE,

--- a/migrations/20220528235714-entry_type.js
+++ b/migrations/20220528235714-entry_type.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.changeColumn("entries", "type", {
+        type: Sequelize.STRING,
+      }),
+    ]);
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return Promise.all([queryInterface.changeColumn("entries", "type")]);
+  },
+};

--- a/models/entry.js
+++ b/models/entry.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
       content: DataTypes.STRING,
       image: DataTypes.STRING,
       categoryId: DataTypes.INTEGER,
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
       deletedAt: DataTypes.DATE,
     },
     {


### PR DESCRIPTION
### Summary

- Changed column 'type' datatype from the Entries table to String instead of Integer.
- Added a new migration file to perform this update in case the migration from the Entries table was already done.
> Usage
`npx sequelize db:migrate`